### PR TITLE
TagAutocompleteField's appearance in admin area

### DIFF
--- a/tagging_autocomplete/models.py
+++ b/tagging_autocomplete/models.py
@@ -15,6 +15,6 @@ class TagAutocompleteField(TagField):
 
         # As an ugly hack, we override the admin widget
         if defaults['widget'] == AdminTextInputWidget:
-            defaults['widget'] = TagAutocomplete
+            defaults['widget'] = TagAutocomplete(attrs={'class': 'vTextField'})
 
         return super(TagAutocompleteField, self).formfield(**defaults)


### PR DESCRIPTION
I noticed that the TagAutocompleteField was shorter than other CharFields in the Django admin area. This fixes this.
