### PR TITLE
Added ability to switch between `istartswith` and `icontains` query filter.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,3 +51,9 @@ By default the maximum number of results suggested by the autocompletion is 100.
 You can modify this number by adding to your `settings.py` project file the `MAX_NUMBER_OF_RESULTS` constant.
 For example::
     MAX_NUMBER_OF_RESULTS = 5
+
+By default autocompletion suggests tags that *start with* a given term.
+In case you need to show ones that *contain* the given term,
+set `TAGGING_AUTOCOMPLETE_SEARCH_CONTAINS` to `True`.
+For example::
+    TAGGING_AUTOCOMPLETE_SEARCH_CONTAINS = True

--- a/tagging_autocomplete/views.py
+++ b/tagging_autocomplete/views.py
@@ -11,10 +11,14 @@ except ImportError:
 
 def list_tags(request):
     max_results = getattr(settings, 'MAX_NUMBER_OF_RESULTS', 100)
+    search_contains = getattr(settings, 'TAGGING_AUTOCOMPLETE_SEARCH_CONTAINS', False)
     try:
-        tags = [{'id': tag.id, 'label': tag.name, 'value': tag.name}
-                for tag in Tag.objects.filter(name__istartswith=request.GET['term'])[:max_results]]
+        term = request.GET['term']
     except MultiValueDictKeyError:
         raise Http404
-
+    if search_contains:
+        objects = Tag.objects.filter(name__icontains=term)
+    else:
+        objects = Tag.objects.filter(name__istartswith=term)
+    tags = [{'id': tag.id, 'label': tag.name, 'value': tag.name} for tag in objects[:max_results]]
     return HttpResponse(json.dumps(tags), content_type='text/json')


### PR DESCRIPTION
Hello Ludwik,

I think that it should be useful to have an ability to switch between tags that start with the given term and tags that contain it.

Best Regards,
Ernest