### PR TITLE
Added `TAGGING_AUTOCOMPLETE_MAX_RESULTS` setting.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,10 @@ your form::
 Optional settings
 ---------------
 By default the maximum number of results suggested by the autocompletion is 100.
-You can modify this number by adding to your `settings.py` project file the `MAX_NUMBER_OF_RESULTS` constant.
+You can modify this number by adding to your `settings.py` project file
+the `TAGGING_AUTOCOMPLETE_MAX_RESULTS` constant.
 For example::
-    MAX_NUMBER_OF_RESULTS = 5
+    TAGGING_AUTOCOMPLETE_MAX_RESULTS = 5
 
 By default autocompletion suggests tags that *start with* a given term.
 In case you need to show ones that *contain* the given term,

--- a/tagging_autocomplete/views.py
+++ b/tagging_autocomplete/views.py
@@ -10,7 +10,11 @@ except ImportError:
 
 
 def list_tags(request):
-    max_results = getattr(settings, 'MAX_NUMBER_OF_RESULTS', 100)
+    # Note that ``MAX_NUMBER_OF_RESULTS`` is deprecated.
+    # Consider using ``TAGGING_AUTOCOMPLETE_MAX_RESULTS`` instead.
+    max_results = getattr(
+        settings, 'TAGGING_AUTOCOMPLETE_MAX_RESULTS',
+        getattr(settings, 'MAX_NUMBER_OF_RESULTS', 100))
     search_contains = getattr(settings, 'TAGGING_AUTOCOMPLETE_SEARCH_CONTAINS', False)
     try:
         term = request.GET['term']


### PR DESCRIPTION
Hello Ludwik,

I added `TAGGING_AUTOCOMPLETE_MAX_RESULTS` setting which *only overrides* `MAX_NUMBER_OF_RESULTS` in order to keep backward compatibility.
Although this setting should reduce the probability of collisions with external settings, the old one still may affect the default value stated in readme.

Best Regards,
Ernest